### PR TITLE
Auto gen doc

### DIFF
--- a/app.go
+++ b/app.go
@@ -40,10 +40,10 @@ func NewKatzenmintApplication(db dbm.DB) *KatzenmintApplication {
 }
 
 func (app *KatzenmintApplication) Info(req abcitypes.RequestInfo) abcitypes.ResponseInfo {
-	epoch := make([]byte, 8)
-	binary.PutUvarint(epoch, app.state.currentEpoch)
+	var epoch [8]byte
+	binary.PutUvarint(epoch[:], app.state.currentEpoch)
 	return abcitypes.ResponseInfo{
-		Data: EncodeHex(epoch),
+		Data: EncodeHex(epoch[:]),
 		// Version:          version.ABCIVersion,
 		// AppVersion:       ProtocolVersion,
 		LastBlockHeight:  app.state.blockHeight,

--- a/app.go
+++ b/app.go
@@ -97,11 +97,11 @@ func (app *KatzenmintApplication) executeTx(tx *Transaction) error {
 	}
 	switch tx.Command {
 	case PublishMixDescriptor:
-		verifier, err := s11n.GetVerifierFromDescriptor([]byte(tx.Payload))
+		payload := []byte(tx.Payload)
+		verifier, err := s11n.GetVerifierFromDescriptor(payload)
 		if err != nil {
 			return err
 		}
-		payload := []byte(tx.Payload)
 		desc, err := s11n.VerifyAndParseDescriptor(verifier, payload, tx.Epoch)
 		if err != nil {
 			return err
@@ -175,7 +175,7 @@ func (app *KatzenmintApplication) CheckTx(req abcitypes.RequestCheckTx) abcitype
 
 // TODO: should update the validators map after commit
 func (app *KatzenmintApplication) Commit() abcitypes.ResponseCommit {
-	appHash := app.state.Commit()
+	appHash, _ := app.state.Commit()
 	return abcitypes.ResponseCommit{Data: appHash}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -156,9 +156,9 @@ func TestPostDocument(t *testing.T) {
 	m.App.BeginBlock(abcitypes.RequestBeginBlock{})
 	res, err := m.BroadcastTxCommit(context.Background(), tx)
 	require.Nil(err)
-	assert.True(res.CheckTx.IsOK())
+	assert.True(res.CheckTx.IsOK(), res.CheckTx.Log)
 	require.NotNil(res.DeliverTx)
-	assert.True(res.DeliverTx.IsOK())
+	assert.True(res.DeliverTx.IsOK(), res.DeliverTx.Log)
 	m.App.Commit()
 
 	// test the data exists in state

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"math"
+
+	katconfig "github.com/katzenpost/authority/voting/server/config"
+	"github.com/katzenpost/core/crypto/rand"
+)
+
+const (
+	DefaultLayers           = 3
+	DefaultMinNodesPerLayer = 2
+	// Note: These values are picked primarily for debugging and need to be changed to something more suitable for a production deployment at some point.
+	defaultSendRatePerMinute    = 100
+	defaultMu                   = 0.00025
+	defaultMuMaxPercentile      = 0.99999
+	defaultLambdaP              = 0.00025
+	defaultLambdaPMaxPercentile = 0.99999
+	defaultLambdaL              = 0.00025
+	defaultLambdaLMaxPercentile = 0.99999
+	defaultLambdaD              = 0.00025
+	defaultLambdaDMaxPercentile = 0.99999
+	defaultLambdaM              = 0.00025
+	defaultLambdaMMaxPercentile = 0.99999
+	absoluteMaxDelay            = 6 * 60 * 60 * 1000 // 6 hours.
+)
+
+var DefaultParameters = katconfig.Parameters{
+	SendRatePerMinute: defaultSendRatePerMinute,
+	Mu:                defaultMu,
+	MuMaxDelay:        uint64(math.Min(rand.ExpQuantile(defaultMu, defaultMuMaxPercentile), absoluteMaxDelay)),
+	LambdaP:           defaultLambdaP,
+	LambdaPMaxDelay:   uint64(rand.ExpQuantile(defaultLambdaP, defaultLambdaPMaxPercentile)),
+	LambdaL:           defaultLambdaL,
+	LambdaLMaxDelay:   uint64(rand.ExpQuantile(defaultLambdaL, defaultLambdaLMaxPercentile)),
+	LambdaD:           defaultLambdaD,
+	LambdaDMaxDelay:   uint64(rand.ExpQuantile(defaultLambdaD, defaultLambdaDMaxPercentile)),
+	LambdaM:           defaultLambdaM,
+	LambdaMMaxDelay:   uint64(rand.ExpQuantile(defaultLambdaM, defaultLambdaMMaxPercentile)),
+}

--- a/errors.go
+++ b/errors.go
@@ -16,10 +16,15 @@ func (err KatzenmintError) Error() string {
 }
 
 var (
-	ErrTxIsNotValidJSON     = KatzenmintError{Msg: "transaction is not valid json string", Code: 1}
-	ErrTxWrongPublicKeySize = KatzenmintError{Msg: "wrong public key size in transaction", Code: 2}
-	ErrTxWrongSignatureSize = KatzenmintError{Msg: "wrong public key size in transaction", Code: 3}
-	ErrTxWrongSignature     = KatzenmintError{Msg: "wrong signature in transaction", Code: 4}
-	ErrTxNonAuthorized      = KatzenmintError{Msg: "non authorized authority", Code: 5}
-	ErrTxCommandNotFound    = KatzenmintError{Msg: "transaction command not found", Code: 6}
+	ErrTxIsNotValidJSON     = KatzenmintError{Msg: "transaction is not valid json string", Code: 0x01}
+	ErrTxWrongPublicKeySize = KatzenmintError{Msg: "wrong public key size in transaction", Code: 0x02}
+	ErrTxWrongSignatureSize = KatzenmintError{Msg: "wrong public key size in transaction", Code: 0x03}
+	ErrTxWrongSignature     = KatzenmintError{Msg: "wrong signature in transaction", Code: 0x04}
+
+	ErrTxDescInvalidVerifier   = KatzenmintError{Msg: "cannot get descriptor verifier", Code: 0x11}
+	ErrTxDescFalseVerification = KatzenmintError{Msg: "cannot verify and parse descriptor", Code: 0x12}
+	ErrTxDescNotSelfSigned     = KatzenmintError{Msg: "descriptor is not self-signed", Code: 0x13}
+
+	ErrTxNonAuthorized   = KatzenmintError{Msg: "non authorized authority", Code: 0x31}
+	ErrTxCommandNotFound = KatzenmintError{Msg: "transaction command not found", Code: 0x32}
 )

--- a/s11n/descriptor.go
+++ b/s11n/descriptor.go
@@ -88,6 +88,19 @@ func GetVerifierFromDescriptor(rawDesc []byte) (cert.Verifier, error) {
 	return d.IdentityKey, nil
 }
 
+func ParseDescriptorWithoutVerify(b []byte) (*pki.MixDescriptor, error) {
+	payload, err := cert.GetCertified(b)
+	if err != nil {
+		return nil, err
+	}
+	d := new(nodeDescriptor)
+	dec := codec.NewDecoderBytes(payload, jsonHandle)
+	if err = dec.Decode(d); err != nil {
+		return nil, err
+	}
+	return &d.MixDescriptor, nil
+}
+
 // VerifyAndParseDescriptor verifies the signature and deserializes the
 // descriptor.  MixDescriptors returned from this routine are guaranteed
 // to have been correctly self signed by the IdentityKey listed in the

--- a/state.go
+++ b/state.go
@@ -161,10 +161,14 @@ func NewKatzenmintState(db dbm.DB) *KatzenmintState {
 			// return true
 		}
 		var protopk pc.PublicKey
-		protopk.Unmarshal(id)
-		pk, err := cryptoenc.PubKeyFromProto(protopk)
+		err = protopk.Unmarshal(id)
 		if err != nil {
 			panic(fmt.Errorf("error unmarshal proto: %v", err))
+			// return true
+		}
+		pk, err := cryptoenc.PubKeyFromProto(protopk)
+		if err != nil {
+			panic(fmt.Errorf("error extraction from proto: %v", err))
 			// return true
 		}
 		state.validators[string(pk.Address())] = protopk

--- a/state_test.go
+++ b/state_test.go
@@ -33,7 +33,7 @@ func TestNewStateBasic(t *testing.T) {
 	// advance block height
 	require.Equal(int64(0), state.blockHeight)
 	state.BeginBlock()
-	state.Commit()
+	_, _ = state.Commit()
 	require.Equal(int64(1), state.blockHeight)
 
 	// test that basic state info can be rebuilt

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@
 package katzenmint
 
 import (
+	"bytes"
 	"encoding/binary"
 
 	"github.com/katzenpost/core/crypto/rand"
@@ -15,21 +16,32 @@ const (
 	descriptorsBucket = "k_descriptors"
 	documentsBucket   = "k_documents"
 	authoritiesBucket = "k_authorities"
+	epochInfoKey      = "k_epoch"
 )
 
-func storageKey(keyPrefix string, keyID []byte, version uint64) (key []byte) {
-	verHex := make([]byte, 8)
-	binary.PutUvarint(verHex, version)
-	verHex = []byte(EncodeHex(verHex))
+func storageKey(keyPrefix string, keyID []byte, epoch uint64) (key []byte) {
+	epochHex := make([]byte, 8)
+	binary.PutUvarint(epochHex, epoch)
+	epochHex = []byte(EncodeHex(epochHex))
 	IDHex := []byte(EncodeHex(keyID))
 
 	key = make([]byte, len(keyPrefix))
 	copy(key, keyPrefix)
 	key = append(key[:], ':')
-	key = append(key[:], verHex[:]...)
+	key = append(key[:], epochHex[:]...)
 	key = append(key[:], ':')
 	key = append(key[:], IDHex[:]...)
 	return
+}
+
+func unpackStorageKey(key []byte) (keyID []byte, epoch uint64) {
+	pre := bytes.Index(key, []byte(":"))
+	post := bytes.Index(key[pre+1:], []byte(":"))
+	epoch, read := binary.Uvarint(key[post+1:])
+	if pre < 0 || post < 0 || read <= 0 {
+		return nil, 0
+	}
+	return key[pre+1 : post], epoch
 }
 
 func generateTopology(nodeList []*descriptor, doc *pki.Document, layers int) [][][]byte {

--- a/util.go
+++ b/util.go
@@ -27,21 +27,25 @@ func storageKey(keyPrefix string, keyID []byte, epoch uint64) (key []byte) {
 
 	key = make([]byte, len(keyPrefix))
 	copy(key, keyPrefix)
-	key = append(key[:], ':')
+	key = append(key[:], []byte(":")...)
 	key = append(key[:], epochHex[:]...)
-	key = append(key[:], ':')
+	key = append(key[:], []byte(":")...)
 	key = append(key[:], IDHex[:]...)
 	return
 }
 
 func unpackStorageKey(key []byte) (keyID []byte, epoch uint64) {
 	pre := bytes.Index(key, []byte(":"))
-	post := bytes.Index(key[pre+1:], []byte(":"))
-	epoch, read := binary.Uvarint(key[post+1:])
-	if pre < 0 || post < 0 || read <= 0 {
+	post := bytes.LastIndex(key, []byte(":"))
+	if pre < 0 || post <= pre {
 		return nil, 0
 	}
-	return key[pre+1 : post], epoch
+	epoch, read := binary.Uvarint(DecodeHex(string(key[pre+1 : post])))
+	keyID = DecodeHex(string(key[post+1:]))
+	if read <= 0 {
+		return nil, 0
+	}
+	return
 }
 
 func generateTopology(nodeList []*descriptor, doc *pki.Document, layers int) [][][]byte {


### PR DESCRIPTION
Resolving issues as described in #25 
* Generate document upon commit, consisting of all uploaded descriptors corresponding to the current epoch
  * Note: the upload document API should be deprecated later
* Be able to reload state information from database
* Testing on document generation
* Move part of the transaction check from `executeTx` to `isTxValid`