### PR TITLE
Reduce state memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 GOPATH=$(shell go env GOPATH)
 GOTAGS="badgerdb"
+VERSION := $(shell git describe --tags 2>/dev/null)
+ifneq ($(VERSION), )
+LD_FLAGS=-ldflags "-X app.ProtocolVersion=$(VERSION)"
+endif
 
 .PHONY: default
 default: lint test
@@ -25,7 +29,7 @@ setup:
 
 .PHONY: build
 build:
-	go build -tags=$(GOTAGS) -o katzenmint cmd/katzenmint/katzenmint.go
+	go build -tags=$(GOTAGS) $(LD_FLAGS) -o katzenmint cmd/katzenmint/katzenmint.go
 
 .PHONY: docker-build
 docker-build:

--- a/app.go
+++ b/app.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ProtocolVersion string = "v0.0.1"
+	ProtocolVersion string = "dev0.0"
 )
 
 var (

--- a/state_test.go
+++ b/state_test.go
@@ -79,34 +79,6 @@ func TestUpdateDescriptor(t *testing.T) {
 	if !bytes.Equal(gotRaw, rawDesc) {
 		t.Fatalf("Got a wrong descriptor from database\n")
 	}
-
-	// test the data exists in memory
-	pk := desc.IdentityKey.ByteArray()
-	if m, ok := state.descriptors[testEpoch]; !ok {
-		t.Fatal("Failed to get mix descriptor from memory\n")
-	} else {
-		gotDesc, ok := m[pk]
-		if !ok {
-			t.Fatal("Failed to get mix descriptor from memory\n")
-		}
-		if !bytes.Equal(gotDesc.raw, rawDesc) {
-			t.Fatalf("Got a wrong descriptor from memory\n")
-		}
-	}
-
-	// test the data can be reloaded into memory
-	state = NewKatzenmintState(kConfig, db)
-	if m, ok := state.descriptors[testEpoch]; !ok {
-		t.Fatal("Failed to reload mix descriptor into memory\n")
-	} else {
-		gotDesc, ok := m[pk]
-		if !ok {
-			t.Fatal("Failed to reload mix descriptor into memory\n")
-		}
-		if !bytes.Equal(gotDesc.raw, rawDesc) {
-			t.Fatalf("Got a wrong descriptor from reloaded memory\n")
-		}
-	}
 }
 
 func TestUpdateDocument(t *testing.T) {

--- a/state_test.go
+++ b/state_test.go
@@ -102,6 +102,8 @@ func TestUpdateDocument(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to update pki document: %+v\n", err)
 	}
+	state.currentEpoch++
+	state.epochStartHeight = state.blockHeight
 	_, err = state.Commit()
 	if err != nil {
 		t.Fatalf("Failed to commit: %v\n", err)
@@ -120,21 +122,19 @@ func TestUpdateDocument(t *testing.T) {
 	}
 
 	// test the data exists in memory
-	gotDoc, ok := state.documents[testEpoch]
-	if !ok {
+	if state.prevDocument == nil {
 		t.Fatal("Failed to get pki document from memory\n")
 	}
-	if !bytes.Equal(gotDoc.raw, sDoc) {
+	if !bytes.Equal(state.prevDocument.raw, sDoc) {
 		t.Fatalf("Got a wrong document from memory\n")
 	}
 
 	// test the data can be reloaded into memory
 	state = NewKatzenmintState(kConfig, db)
-	gotDoc, ok = state.documents[testEpoch]
-	if !ok {
+	if state.prevDocument == nil {
 		t.Fatal("Failed to reload pki document into memory\n")
 	}
-	if !bytes.Equal(gotDoc.raw, sDoc) {
+	if !bytes.Equal(state.prevDocument.raw, sDoc) {
 		t.Fatalf("Got a wrong document from reloaded memory\n")
 	}
 }
@@ -256,9 +256,8 @@ func TestDocumentGenerationUponCommit(t *testing.T) {
 	}
 
 	// test the non-existence of the document
-	_, ok := state.documents[epoch]
 	_, err = state.Get(key)
-	if ok || err == nil {
+	if state.prevDocument != nil || err == nil {
 		t.Fatalf("The pki document should not be generated at this moment because there is not enough mix descriptors\n")
 	}
 
@@ -274,19 +273,17 @@ func TestDocumentGenerationUponCommit(t *testing.T) {
 	}
 
 	// test the existence of the document
-	doc, ok := state.documents[epoch]
 	_, err = state.Get(key)
-	if !ok || err != nil {
+	if state.prevDocument == nil || err != nil {
 		t.Fatalf("The pki document should be generated automatically\n")
 	}
 
 	// test the document can be reloaded
-	state = NewKatzenmintState(kConfig, db)
-	got, ok := state.documents[epoch]
-	if !ok {
+	newState := NewKatzenmintState(kConfig, db)
+	if newState.prevDocument == nil {
 		t.Fatalf("The pki document should be reloaded\n")
 	}
-	if !bytes.Equal(got.raw, doc.raw) {
+	if !bytes.Equal(newState.prevDocument.raw, state.prevDocument.raw) {
 		t.Fatalf("Reloaded doc inconsistent with the generated doc\n")
 	}
 }


### PR DESCRIPTION
**Intro**
The original katzenmint state keeps track of the received descriptors and documents for each epoch in memory. This is actually not necessary, as the current ones are the only thing relevant,. Old ones are saved in IAVL tree, which can still be retrieved.

**Change**
* Remove state.descriptors, state.documents, state.deferCommit
* Add state.prevDocument (to faciliate state.generateDocument())
* Use state.Get(storageKey(descriptorBucket, ...)) instead of state.descriptors[][]
* Use state.Get(storageKey(documentBucket, ...)) instead of state.document[]
